### PR TITLE
Fixed passing selected Test data to test-instruction page

### DIFF
--- a/client/esm-client/src/Teacher/AssigenedTest/TestList.js
+++ b/client/esm-client/src/Teacher/AssigenedTest/TestList.js
@@ -46,7 +46,7 @@ export default function TestList(props) {
     selectRef = e.currentTarget;
     e.currentTarget.classList.add("selected__test");
     selectedData = tests[index];
-    console.log(selectedData);
+    console.log("Selected",selectedData);
     //console.log();
   };
 

--- a/client/esm-client/src/TestInstructions/TestInstruction.js
+++ b/client/esm-client/src/TestInstructions/TestInstruction.js
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import { Row, Modal, Col, Button } from "antd";
 import { connect } from "react-redux";
 import "./TestInstruction.css";
@@ -34,6 +34,11 @@ function TestInstruction(props) {
       attempted=true
     }
   })
+
+  useEffect(()=>{
+    console.log(props)
+
+  },[])
 
   const handleButtonClick = () => {
     confirm({

--- a/client/esm-client/src/actions/selectActions.js
+++ b/client/esm-client/src/actions/selectActions.js
@@ -24,6 +24,7 @@ const selectAssignedTest = (testData) => {
 };
 
 export const selectedTest = (data) => (dispatch) => {
+  console.log("data",data)
   dispatch(selectTest(data));
 };
 

--- a/client/esm-client/src/attemptTest/SelectTest.js
+++ b/client/esm-client/src/attemptTest/SelectTest.js
@@ -9,7 +9,9 @@ function SelectTest(props) {
   const { tests, studentClassName, profileID } = props;
 
   const handleSelectedTest =(testData)=>{
+      console.log("Selected Test Data:", testData); 
       props.selectedTest(testData);
+      console.log("handleSelectedTest",testData)
   }
 
   useEffect(() => {

--- a/client/esm-client/src/attemptTest/TestList.js
+++ b/client/esm-client/src/attemptTest/TestList.js
@@ -9,7 +9,7 @@ export default function TestList(props) {
   const [tests, setTests] = useState([]);
   const [searchTests, setSearchTests] = useState([]);
   const [searching, setSearching] = useState("");
-  const [selectedTest, setSelectedTest] = useState(null);
+  const [selectedTest, setSelectedTest] = useState(null); // Use state to track selected test
 
   useEffect(() => {
     setTests(props.tests.reverse());
@@ -25,24 +25,21 @@ export default function TestList(props) {
     }
   };
 
-  let selectRef,
-    selectedData = {};
-
   const handleButtonClick = () => {
-    props.handleSelectedTest(selectedData);
-    history.push("/test-instructions");
+    // Now passing the state value of selectedTest
+    if (selectedTest) {
+      props.handleSelectedTest(selectedTest);
+      history.push("/test-instructions");
+      console.log("Selected Test Data:", selectedTest); // Log selected test data
+    }
   };
 
   const handleSelectTest = (e, index) => {
-    if (selectRef) {
-      selectRef.classList.remove("selected__test");
-    }
-    selectRef = e.currentTarget;
-    e.currentTarget.classList.add("selected__test");
-    selectedData = tests[index];
-    setSelectedTest(tests[index]);
+    // Set the selected test using useState
+    const test = tests[index];
+    setSelectedTest(test); // Update the state with the selected test
 
-    //console.log();
+    console.log("Selected Test:", test);
   };
 
   return (
@@ -63,18 +60,12 @@ export default function TestList(props) {
                     <div
                       key={index}
                       className={`test__wrapper`}
-                      onClick={(e) => {
-                        handleSelectTest(e, index);
-                      }}
+                      onClick={(e) => handleSelectTest(e, index)}
                     >
-                      <p className="select__test" key={index}>
-                        {test.testName}
-                      </p>
+                      <p className="select__test">{test.testName}</p>
                       <div className="test__time">
                         <p className="time start">Duration: {test.minutes} min</p>
-                        <p className="time end">Max Marks: {test.outOfMarks}
-                  
-                        </p>
+                        <p className="time end">Max Marks: {test.outOfMarks}</p>
                       </div>
                     </div>
                   ))
@@ -83,13 +74,9 @@ export default function TestList(props) {
                     <div
                       key={index}
                       className={`test__wrapper`}
-                      onClick={(e) => {
-                        handleSelectTest(e, index);
-                      }}
+                      onClick={(e) => handleSelectTest(e, index)}
                     >
-                      <p className="select__test" key={index}>
-                        {test.testName}
-                      </p>
+                      <p className="select__test">{test.testName}</p>
                       <div className="test__time">
                         <p className="time start">Duration: {test.minutes} min</p>
                         <p className="time end">Max Marks: {test.outOfMarks}</p>
@@ -144,7 +131,7 @@ export default function TestList(props) {
           </div>
         </div>
         <div className="select__button">
-         <Button
+          <Button
             type="primary"
             onClick={handleButtonClick}
             disabled={!selectedTest} // Disable button if no test is selected

--- a/client/esm-client/src/result/TestList.js
+++ b/client/esm-client/src/result/TestList.js
@@ -44,7 +44,7 @@ export default function TestList(props) {
     selectRef = e.currentTarget;
     e.currentTarget.classList.add("selected__test");
     selectedData = tests[index];
-    console.log("tests",tests);
+    console.log("selected tests",tests);
   };
 
   return (


### PR DESCRIPTION
**Issue:**
Test data was not properly passed to the Instruction page after selecting a test and clicking "Continue" on the Attempt-test page.

**Fix:**
Ensured that the correct test data is now properly passed from the Attempt-test page to the Instruction page.

**Changes Made:**

- Fixed data transfer between pages to ensure the Instruction page receives the correct test data.