### PR TITLE
 Disable "Continue" Button and Add Tooltip for Disabled State

### DIFF
--- a/client/esm-client/src/TestInstructions/TestInstruction.js
+++ b/client/esm-client/src/TestInstructions/TestInstruction.js
@@ -36,7 +36,7 @@ function TestInstruction(props) {
   })
 
   useEffect(()=>{
-    console.log(props)
+    console.log("Selected Test in Instructions: ",props.selectedTest.submitBy)
 
   },[])
 

--- a/client/esm-client/src/TestInstructions/TestInstruction.js
+++ b/client/esm-client/src/TestInstructions/TestInstruction.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Row, Modal, Col, Button } from "antd";
+import { Row, Modal, Col, Button, Tooltip } from "antd";
 import { connect } from "react-redux";
 import "./TestInstruction.css";
 import { FaArrowCircleRight } from "react-icons/fa";
@@ -37,6 +37,7 @@ function TestInstruction(props) {
 
   // State to manage the 'Continue' button enabled/disabled status
   const [isButtonDisabled, setIsButtonDisabled] = useState(false);
+  const [tooltipMessage, setTooltipMessage] = useState('');
 
   // Get profileID from localStorage and check if it matches
   const localStorageProfileID = localStorage.getItem('profileID');
@@ -44,9 +45,14 @@ function TestInstruction(props) {
   useEffect(() => {
     // Check if profileID matches with the selected test submitBy[0][0].profileID
     if (submitBy && submitBy[0] && submitBy[0][0]?.profileID === localStorageProfileID) {
-      setIsButtonDisabled(true); // Disable the button if profileID matches
+      setIsButtonDisabled(true);
+      setTooltipMessage('You have already submitted this test.');
+    } else if (attempted) {
+      setIsButtonDisabled(true);
+      setTooltipMessage('You have already attempted this test.');
     } else {
-      setIsButtonDisabled(attempted); // Disable the button if the test is already attempted
+      setIsButtonDisabled(false);
+      setTooltipMessage('');
     }
   }, [submitBy, localStorageProfileID, testName, attempted]);
 
@@ -183,13 +189,18 @@ function TestInstruction(props) {
                       </div>
                     </div>
                     <div className="select__button">
-                      <Button
-                        type="primary"
-                        onClick={handleButtonClick}
-                        disabled={isButtonDisabled}
+                      <Tooltip
+                        title={tooltipMessage}
+                        visible={isButtonDisabled}
                       >
-                        Continue
-                      </Button>
+                        <Button
+                          type="primary"
+                          onClick={handleButtonClick}
+                          disabled={isButtonDisabled}
+                        >
+                          Continue
+                        </Button>
+                      </Tooltip>
                     </div>
                   </div>
                 </Col>

--- a/client/esm-client/src/TestInstructions/TestInstruction.js
+++ b/client/esm-client/src/TestInstructions/TestInstruction.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 import { Row, Modal, Col, Button } from "antd";
 import { connect } from "react-redux";
 import "./TestInstruction.css";
@@ -7,10 +7,9 @@ import { ExclamationCircleOutlined } from "@ant-design/icons";
 import { useHistory } from "react-router-dom";
 
 function TestInstruction(props) {
-  //console.log(props.selectedTest);
   const history = useHistory();
   const { confirm } = Modal;
-  const { tests} = props;
+  const { tests } = props;
   const {
     outOfMarks,
     questions,
@@ -20,33 +19,43 @@ function TestInstruction(props) {
     testName,
     rules,
     _id: testID,
+    submitBy
   } = props.selectedTest;
 
-  let testRules, attempted=false;
+  let testRules, attempted = false;
 
   if (rules) {
     testRules = rules;
   }
-  
 
-  tests.map((test, index)=>{
-    if(test.testName === testName){
-      attempted=true
+  // Check if the test has been attempted
+  tests.map((test, index) => {
+    if (test.testName === testName) {
+      attempted = true;
     }
-  })
+  });
 
-  useEffect(()=>{
-    console.log("Selected Test in Instructions: ",props.selectedTest.submitBy)
+  // State to manage the 'Continue' button enabled/disabled status
+  const [isButtonDisabled, setIsButtonDisabled] = useState(false);
 
-  },[])
+  // Get profileID from localStorage and check if it matches
+  const localStorageProfileID = localStorage.getItem('profileID');
+
+  useEffect(() => {
+    // Check if profileID matches with the selected test submitBy[0][0].profileID
+    if (submitBy && submitBy[0] && submitBy[0][0]?.profileID === localStorageProfileID) {
+      setIsButtonDisabled(true); // Disable the button if profileID matches
+    } else {
+      setIsButtonDisabled(attempted); // Disable the button if the test is already attempted
+    }
+  }, [submitBy, localStorageProfileID, testName, attempted]);
 
   const handleButtonClick = () => {
     confirm({
       title: "Do you give test now?",
       icon: <ExclamationCircleOutlined />,
-      content: "Once you click OK , timer will start!",
+      content: "Once you click OK, the timer will start!",
       onOk() {
-        // console.log(props.selectedTest);
         console.log("OK");
         history.push("/start-test");
       },
@@ -146,8 +155,8 @@ function TestInstruction(props) {
                           Previous
                         </Button>
                         <p className="button__description">
-                          Next: By clicking Next button next question will
-                          appear to user
+                          Previous: By clicking Previous button previous
+                          question will appear to user
                         </p>
                       </div>
                       <div className="navigation__buttons__Feature">
@@ -158,8 +167,7 @@ function TestInstruction(props) {
                           Flag
                         </Button>
                         <p className="button__description">
-                          Flag: By clicking Next button next question will
-                          appear to user
+                          Flag: Mark this question to revisit later
                         </p>
                       </div>
                       <div className="navigation__buttons__Feature">
@@ -170,8 +178,7 @@ function TestInstruction(props) {
                           End Test
                         </Button>
                         <p className="button__description">
-                          End Test: By clicking Next button next question will
-                          appear to user
+                          End Test: Finish the test early
                         </p>
                       </div>
                     </div>
@@ -179,7 +186,7 @@ function TestInstruction(props) {
                       <Button
                         type="primary"
                         onClick={handleButtonClick}
-                        disabled={attempted}
+                        disabled={isButtonDisabled}
                       >
                         Continue
                       </Button>
@@ -198,7 +205,7 @@ function TestInstruction(props) {
 const mapStateToProps = (state) => {
   return {
     selectedTest: state.selectedTest.selectedTestData,
-     tests: state.tests.attemptedTest,
+    tests: state.tests.attemptedTest,
   };
 };
 


### PR DESCRIPTION
**Description:**
- The "Continue" button is disabled if the user has already attempted or submitted the test, based on `profileID` in `localStorage` and test data.
- A `Tooltip` appears on hover for disabled buttons, explaining why the test can't be attempted (e.g., "You have already submitted this test").
- Used `useState` and `useEffect` to manage button state and tooltip message.

**Testing Steps:**
1. Verify the button is disabled for users who have already attempted or submitted the test.
2. Hover over the disabled button to check the tooltip message.